### PR TITLE
feat: 이미지 업로드 Controller 구현

### DIFF
--- a/server/EverybodyChachapark/src/docs/asciidoc/EverbodyChachapark.adoc
+++ b/server/EverybodyChachapark/src/docs/asciidoc/EverbodyChachapark.adoc
@@ -429,3 +429,34 @@ include::{snippets}/delete-cart/request-headers.adoc[]
 include::{snippets}/delete-cart/http-response.adoc[]
 
 
+== OrderController
+
+== ImageController
+=== 이미지 업로드
+.curl-request
+include::{snippets}/post-images-upload/curl-request.adoc[]
+
+.request-headers
+include::{snippets}/post-images-upload/request-headers.adoc[]
+
+.request-parts
+include::{snippets}/post-images-upload/request-parts.adoc[]
+
+.http-response
+include::{snippets}/post-images-upload/http-response.adoc[]
+
+.response-fields
+include::{snippets}/post-images-upload/response-fields.adoc[]
+
+=== 이미지 다운로드
+.curl-request
+include::{snippets}/get-image-download/curl-request.adoc[]
+
+.http-request
+include::{snippets}/get-image-download/http-request.adoc[]
+
+.path-parameters
+include::{snippets}/get-image-download/path-parameters.adoc[]
+
+.http-response
+include::{snippets}/get-image-download/http-response.adoc[]

--- a/server/EverybodyChachapark/src/main/java/com/DuTongChitongYutong/EverybodyChachapark/domain/image/controller/ImageController.java
+++ b/server/EverybodyChachapark/src/main/java/com/DuTongChitongYutong/EverybodyChachapark/domain/image/controller/ImageController.java
@@ -2,6 +2,7 @@ package com.DuTongChitongYutong.EverybodyChachapark.domain.image.controller;
 
 import com.DuTongChitongYutong.EverybodyChachapark.domain.image.facade.FacadeImage;
 import com.DuTongChitongYutong.EverybodyChachapark.domain.image.service.StorageService;
+import com.DuTongChitongYutong.EverybodyChachapark.response.ImageURLResponseDto;
 import com.DuTongChitongYutong.EverybodyChachapark.response.SingleResponseDto;
 import com.DuTongChitongYutong.EverybodyChachapark.util.JsonListHelper;
 import lombok.AllArgsConstructor;
@@ -22,11 +23,11 @@ public class ImageController {
     final private FacadeImage facadeImage;
     final private JsonListHelper jsonListHelper;
 
-    @PostMapping // Image Upload Test
-    public ResponseEntity postImage(@RequestPart(name = "imageFile") List<MultipartFile> imageFile) {
+    @PostMapping("/upload") // Image Upload Test
+    public ResponseEntity postImage(@RequestPart(name = "imageFile", required = false) List<MultipartFile> imageFile) {
         String imageURL = facadeImage.createImageURLs(imageFile);
 
-        return new ResponseEntity<>(new SingleResponseDto<>(imageURL), HttpStatus.CREATED);
+        return new ResponseEntity<>(new ImageURLResponseDto<>(jsonListHelper.jsonToList(imageURL)), HttpStatus.CREATED);
     }
 
     @GetMapping("/{image-name}")

--- a/server/EverybodyChachapark/src/main/java/com/DuTongChitongYutong/EverybodyChachapark/response/ImageURLResponseDto.java
+++ b/server/EverybodyChachapark/src/main/java/com/DuTongChitongYutong/EverybodyChachapark/response/ImageURLResponseDto.java
@@ -1,0 +1,16 @@
+package com.DuTongChitongYutong.EverybodyChachapark.response;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ImageURLResponseDto <T> {
+    private List<T> data;
+    private int totalElements;
+
+    public ImageURLResponseDto(List<T> imageURL) {
+        this.data = imageURL;
+        this.totalElements = imageURL.size();
+    }
+}

--- a/server/EverybodyChachapark/src/test/java/com/DuTongChitongYutong/EverybodyChachapark/slice/Image/ImageControllerTest.java
+++ b/server/EverybodyChachapark/src/test/java/com/DuTongChitongYutong/EverybodyChachapark/slice/Image/ImageControllerTest.java
@@ -1,0 +1,131 @@
+package com.DuTongChitongYutong.EverybodyChachapark.slice.Image;
+
+import com.DuTongChitongYutong.EverybodyChachapark.domain.image.controller.ImageController;
+import com.DuTongChitongYutong.EverybodyChachapark.domain.image.facade.FacadeImage;
+import com.DuTongChitongYutong.EverybodyChachapark.util.GetMockMultipartFile;
+import com.DuTongChitongYutong.EverybodyChachapark.util.JsonListHelper;
+import com.google.gson.Gson;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.List;
+
+import static com.DuTongChitongYutong.EverybodyChachapark.util.ApiDocumentUtils.getRequestPreProcessor;
+import static com.DuTongChitongYutong.EverybodyChachapark.util.ApiDocumentUtils.getResponsePreProcessor;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+
+@WebMvcTest(ImageController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@AutoConfigureRestDocs
+@AutoConfigureMockMvc(addFilters = false)
+public class ImageControllerTest {
+    private final static String IMAGE_DEFAULT_URL = "/images";
+
+    @Autowired
+    private Gson gson;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private FacadeImage facadeImage;
+
+    @MockBean
+    private JsonListHelper jsonListHelper;
+
+    @Test
+    public void postUploadImage() throws Exception {
+        // given
+        String imageURL = "[\"http://localhost:8080/images/NotfoundImage.jpg\"]";
+
+        given(facadeImage.createImageURLs(Mockito.anyList())).willReturn(imageURL);
+
+        List<String> imageURLs = List.of("http://localhost:8080/images/NotfoundImage.jpg");
+
+        given(jsonListHelper.jsonToList(Mockito.anyString())).willReturn(imageURLs);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer ".concat("adfadf"));
+        headers.add("Refresh", "adasdsad");
+
+        // when
+        ResultActions postAction =
+                mockMvc.perform(
+                        multipart(IMAGE_DEFAULT_URL + "/upload")
+                                .file(GetMockMultipartFile.getMockMultipartFile("imageFile"))
+                                .accept(MediaType.APPLICATION_JSON)
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                                .headers(headers)
+                );
+
+        // then
+        postAction
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data[0]").value(imageURLs.get(0)))
+                .andDo(document(
+                        "post-images-upload",
+                        getRequestPreProcessor(),
+                        getResponsePreProcessor(),
+                        requestHeaders(
+                                List.of(headerWithName("Authorization").description("인증에 필요한 " +
+                                                "Access Token (Ex. Bearer eyJhbG...) `Bearer ` 문자열을 access token 앞에 붙여야 한다."),
+                                        headerWithName("Refresh").description("토큰 재발급에 필요한 " +
+                                                "Refresh Token (Ex. eyJhbG...)")
+                                )
+                        ),
+                        requestParts(
+                                partWithName("imageFile").description("업로드할 이미지 첨부 파일(복수가능, NULL가능)")
+                        ),
+                        responseFields(
+                                List.of(fieldWithPath("data[]").type(JsonFieldType.ARRAY).description("이미지 URL"),
+                                        fieldWithPath("totalElements").type(JsonFieldType.NUMBER).description("응답된 URL 개수")
+                                )
+                        )
+                ));
+
+    }
+
+    @Test
+    public void getDownloadImage() throws Exception {
+        String imageFileName = "NotfoundImage.jpg";
+
+        given(facadeImage.loadImage(Mockito.anyString())).willReturn(null);
+
+        ResultActions getAction =
+                mockMvc.perform(
+                        get(IMAGE_DEFAULT_URL + "/{image-name}", imageFileName)
+                );
+
+        getAction
+                .andExpect(status().isOk())
+                .andDo(document(
+                        "get-image-download",
+                        getRequestPreProcessor(),
+                        getResponsePreProcessor(),
+                        pathParameters(
+                                parameterWithName("image-name").description("요청 이미지 파일명(ex. 1512412-23125-4123.jpg)")
+                        )
+                ));
+    }
+
+}


### PR DESCRIPTION
### PR Title
<!-- pr 제목을 입력 해주세요. -->
- feat: 이미지 업로드 Controller 구현

### PR Body
<!-- 개발한 내용에 대한 설명을 적어주세요. -->
1. feat: 이미지 업로드 Controller 구현
   - 여러개의 이미지 업로드 요청을 수용하여 이미지를 Application에 저장이 되고 그 이미지의 조회를 위한 URL를 응답함
   - Image Controller Slice Test case 생성
   - Image Rest Docs 출간

### PR Footer
<!-- issuetraker ID 명시 또는 기타 추가사항이 있을 경우 작성해주세요 -->
- Related To: #17
